### PR TITLE
Pull network fixes into Darwin branch

### DIFF
--- a/lib/dnsmasq/dnsmasq.go
+++ b/lib/dnsmasq/dnsmasq.go
@@ -25,7 +25,10 @@ var containerConfig container.Config = container.Config{
 		"53/tcp": struct{}{},
 		"53/udp": struct{}{},
 	},
-	Cmd: []string{"-S", fmt.Sprintf("/docker/%v", LoopbackAddress)}, // Tells dnsmasq to forward all requests for *.docker domains to our special loopback address.
+	Cmd: []string{
+		"--log-facility=-", "--listen-address=0.0.0.0",
+		"--interface=eth0", "--interface=docker0",
+		"-A", fmt.Sprintf("/docker/%v", LoopbackAddress)}, // Tells dnsmasq to forward all requests for *.docker domains to our special loopback address.
 }
 
 var hostConfig container.HostConfig = container.HostConfig{

--- a/lib/docker/docker.go
+++ b/lib/docker/docker.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"context"
+	"io"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -83,12 +84,16 @@ func StartContainer(imageName string, hostConfig *container.HostConfig, containe
 		}
 	}
 
-	reader, err := client.ImagePull(ctx, imageName, types.ImagePullOptions{})
+	reader, err := client.ImagePull(ctx, imageName, types.ImagePullOptions{Platform: "linux/arm64"})
 
 	if err != nil {
 		return err
 	}
+
+	// We have to write the stream of data from pulling the image, otherwise we
+	// won't actually pull the image.
 	defer reader.Close()
+	io.Copy(io.Discard, reader)
 
 	ref, err := client.ContainerCreate(ctx,
 		containerConfig,

--- a/lib/networking/darwin/darwin.go
+++ b/lib/networking/darwin/darwin.go
@@ -21,7 +21,8 @@ var loopbackAlreadyDeletedRegex regexp.Regexp = *regexp.MustCompile("(SIOCDIFADD
 
 // The command that adds our custom resolver for *.docker domains. By running through the shell, we
 // can ask for sudo only when we need it, rather than requiring a user to run falcon with sudo.
-var addResolverCmd string = fmt.Sprintf(`echo "nameserver %v" | sudo tee %v > /dev/null`, dnsmasq.LoopbackAddress, dockerResolverPath)
+var addResolverCmd string = fmt.Sprintf(`echo "nameserver %v
+port 53" | sudo tee %v > /dev/null`, dnsmasq.LoopbackAddress, dockerResolverPath)
 
 // Configure configures the host machine's networking to allow the falcon-proxy to work it's magic.
 func Configure() {

--- a/lib/proxy/proxy.go
+++ b/lib/proxy/proxy.go
@@ -47,7 +47,7 @@ func Start() {
 }
 
 func Stop() {
-	logger.LogInfo("Removing the falcon proxy container...")
+	logger.LogInfo("Stopping the falcon proxy container...")
 	if err := docker.RemoveContainer(ProxyContainerName); err != nil {
 		logger.LogError("Unable to remove the proxy container due to the following error: \n%v", err)
 	}


### PR DESCRIPTION
This commit introduces lots of fixes for dnsmasq and other general
networking fixes. The bugs arose entirely because networking and dnsmasq
are both still very new to me, so I had to do a lot of tinkering to get
them working. Fixes include:

1. We actually write what port to listen on in the /etc/resolver/docker
   file. This way, the system knows to send all DNS queries to our
   special loopback address on port 53.
2. The dnsmasq container is listening on port 53 and is now properly
   setup to resolve all DNS requests for *.docker domains to the
   loopback address. Note this involved shifting from -S which specifies
   a nameserver (not what we want) to -A, which specifies an domain and
   associated address (what we do want). Thank you dory-dnmasq for being
   open source so I could figure that one out. In addition, I also had
   to specify a listen address of 0.0.0.0 so that dnsmasq would listen
   to non-local requests, and tell it to use the eth0 and docker0
   network interfaces.
3. The docker.StartContainer method will now actually pull the specified
   docker image. This wasn't happening before because we weren't
   actually copying the output from the io.Reader client.ImagePull
   provided.

Networking is hard :(