### PR TITLE
Tls

### DIFF
--- a/cmd/tls.go
+++ b/cmd/tls.go
@@ -1,0 +1,58 @@
+/*
+Copyright © 2022 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"github.com/Hawkbawk/falcon/lib/logger"
+	"github.com/Hawkbawk/falcon/lib/proxy"
+	"github.com/spf13/cobra"
+)
+
+// tlsCmd represents the tls command
+var tlsCmd = &cobra.Command{
+	Use:   "tls <domain_name>",
+	Short: "The tls command lets you enable TLS for a domain of your choosing",
+	Long: `You can use the tls command to enable TLS/HTTPS for
+the domain of your choosing. If your application needs HTTPS
+to work properly, this is the way to do it. Just run the tls command
+on the domain that matches your application and then enable TLS for your
+container by putting a label that matches the format:
+"traefik.http.routers.<your_router_name>.tls=true"
+`,
+	ValidArgs: []string{"domain_name"},
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) != 1 {
+			logger.LogError("You must specify a hostname and only a hostname!")
+		}
+
+		if err := proxy.EnableTlsForHost(args[0]); err != nil {
+			logger.LogError("Unable to enable TLS for the specified host:\n%v", err)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(tlsCmd)
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// tlsCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// tlsCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/go.mod
+++ b/go.mod
@@ -15,4 +15,5 @@ require (
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
+	gopkg.in/yaml.v2 v2.4.0
 )

--- a/lib/dnsmasq/dnsmasq.go
+++ b/lib/dnsmasq/dnsmasq.go
@@ -15,13 +15,13 @@ import (
 const LoopbackAddress = "192.168.40.1"
 
 // The name of the dnsmasq image we use.
-const DnsMasqImageName = "4km3/dnsmasq:2.85-r2"
+const dnsMasqImageName = "4km3/dnsmasq:2.85-r2"
 
 // The name of the dnsmasq container when it's running.
-const DnsMasqContainerName = "falcon-dnsmasq"
+const dnsMasqContainerName = "falcon-dnsmasq"
 
 var containerConfig *container.Config = &container.Config{
-	Image: DnsMasqImageName,
+	Image: dnsMasqImageName,
 	ExposedPorts: nat.PortSet{
 		"53/tcp": struct{}{},
 		"53/udp": struct{}{},
@@ -52,10 +52,10 @@ var hostConfig *container.HostConfig = &container.HostConfig{
 
 // Starts our dnsmasq container.
 func Start(client docker.DockerClient) error {
-	return client.StartContainer(DnsMasqImageName, hostConfig, containerConfig, DnsMasqContainerName)
+	return client.StartContainer(dnsMasqImageName, hostConfig, containerConfig, dnsMasqContainerName)
 }
 
 // Stops our dnsmasq container.
 func Stop(client docker.DockerClient) error {
-	return client.StopAndRemoveContainer(DnsMasqContainerName)
+	return client.StopAndRemoveContainer(dnsMasqContainerName)
 }

--- a/lib/dnsmasq/dnsmasq_test.go
+++ b/lib/dnsmasq/dnsmasq_test.go
@@ -22,14 +22,14 @@ var _ = Describe("Dnsmasq", func() {
 
 	Describe("Start", func() {
 		It("tries to start the dnsmasq container and returns no errors", func() {
-			mockClient.EXPECT().StartContainer(DnsMasqImageName, hostConfig, containerConfig, DnsMasqContainerName).Return(nil)
+			mockClient.EXPECT().StartContainer(dnsMasqImageName, hostConfig, containerConfig, dnsMasqContainerName).Return(nil)
 
 			Expect(Start(mockClient)).Should(Succeed())
 		})
 
 		It("returns an error if the container can't be started", func() {
 			err := fmt.Errorf("problems!")
-			mockClient.EXPECT().StartContainer(DnsMasqImageName, hostConfig, containerConfig, DnsMasqContainerName).Return(err)
+			mockClient.EXPECT().StartContainer(dnsMasqImageName, hostConfig, containerConfig, dnsMasqContainerName).Return(err)
 
 			Expect(Start(mockClient)).Should(Equal(err))
 		})
@@ -37,14 +37,14 @@ var _ = Describe("Dnsmasq", func() {
 
 	Describe("Stop", func() {
 		It("tries to stop the dnsmasq container and returns no errors", func() {
-			mockClient.EXPECT().StopAndRemoveContainer(DnsMasqContainerName).Return(nil)
+			mockClient.EXPECT().StopAndRemoveContainer(dnsMasqContainerName).Return(nil)
 
 			Expect(Stop(mockClient)).Should(Succeed())
 		})
 
 		It("returns an error if the container can't be stopped", func() {
 			err := fmt.Errorf("problems!")
-			mockClient.EXPECT().StopAndRemoveContainer(DnsMasqContainerName).Return(err)
+			mockClient.EXPECT().StopAndRemoveContainer(dnsMasqContainerName).Return(err)
 
 			Expect(Stop(mockClient)).Should(Equal(err))
 		})

--- a/lib/proxy/proxy.go
+++ b/lib/proxy/proxy.go
@@ -1,15 +1,31 @@
 package proxy
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/Hawkbawk/falcon/lib/docker"
+	"github.com/Hawkbawk/falcon/lib/shell"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/go-connections/nat"
+	"gopkg.in/yaml.v2"
 )
 
 const ProxyImageName = "hawkbawk/falcon-proxy"
 const ProxyContainerName = "falcon-proxy"
+const ProxyBaseDir = "/usr/src/app"
+const defaultConfig = `
+# This is where falcon will add any info about any certificates that it creates for you.
+# Alternatively, you can put any info about your own certificates here.
+# See https://doc.traefik.io/traefik/https/tls/#user-defined for more info.
+tls:
+  certificates: {}
+`
 
-var containerConfig container.Config = container.Config{
+var certificatesDir = fmt.Sprintf("%v/.falcon/certs", os.Getenv("HOME"))
+var dynamicConfigPath = fmt.Sprintf("%v/.falcon/dynamic.yml", os.Getenv("HOME"))
+
+var containerConfig *container.Config = &container.Config{
 	Image: ProxyImageName,
 	ExposedPorts: nat.PortSet{
 		"80": struct{}{},
@@ -21,9 +37,10 @@ var containerConfig container.Config = container.Config{
 	},
 }
 
-var hostConfig container.HostConfig = container.HostConfig{
+var hostConfig *container.HostConfig = &container.HostConfig{
 	Binds: []string{
 		"/var/run/docker.sock:/var/run/docker.sock:ro",
+		"~/.falcon:/usr/src/app",
 	},
 	PortBindings: nat.PortMap{
 		"80": []nat.PortBinding{
@@ -35,11 +52,120 @@ var hostConfig container.HostConfig = container.HostConfig{
 	},
 }
 
-// Start starts up the falcon-proxy so that it can start forwarding requests.
-func Start(client docker.DockerClient) error {
-	return client.StartContainer(ProxyImageName, &hostConfig, &containerConfig, ProxyContainerName)
+type TlsFilesConfig struct {
+	CertFile string `yaml:"certFile,omitempty"`
+	KeyFile  string `yaml:"keyFile,omitempty"`
 }
 
+type DynamicConfig struct {
+	Tls struct {
+		Certificates []TlsFilesConfig `yaml:"certificates,omitempty"`
+	} `yaml:"tls,omitempty"`
+}
+
+// Start starts up the falcon-proxy so that it can start forwarding requests.
+func Start(client docker.DockerClient) error {
+	return client.StartContainer(ProxyImageName, hostConfig, containerConfig, ProxyContainerName)
+}
+
+// Stop stops the falcon-proxy container.
 func Stop(client docker.DockerClient) error {
 	return client.StopAndRemoveContainer(ProxyContainerName)
+}
+
+// EnableTlsForHost creates the certificate files necessary for the specified
+// hostname in the falcon certs directory and adds them to the Traefik dynamic
+// config that gets mounted inside the falcon-proxy container.
+func EnableTlsForHost(hostname string) error {
+	if err := ensureDynamicConfig(); err != nil {
+		return err
+	}
+
+	if err := createTlsFiles(hostname, shell.RunCommand); err != nil {
+		return err
+	}
+
+	config, err := os.ReadFile(dynamicConfigPath)
+
+	if err != nil {
+		return err
+	}
+
+	newConfig, err := addFilesToConfig(hostname, config)
+
+	if err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(dynamicConfigPath, []byte(newConfig), 0755); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// createTlsFiles creates the key and cert file for the specified hostname
+// in the falcon directory.
+func createTlsFiles(hostname string, cmdRunner func(string) error) error {
+
+	// In an ideal world, we'd just be able to tell mkcert where
+	// we want the certificates, but due to a bug in mkcerts arg parsing code,
+	// we can't do that. That would be much easier to test, but this works for
+	// now.
+	if err := os.Chdir(certificatesDir); err != nil {
+		return err
+	}
+
+	if err := cmdRunner(fmt.Sprintf("mkcert %v", hostname)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// addFilesToConfig adds the key and cert files for the specified hostname
+// to the Traefik dynamic config.
+func addFilesToConfig(hostname string, data []byte) ([]byte, error) {
+	config := DynamicConfig{}
+
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return nil, err
+	}
+
+	certFilePath := fmt.Sprintf("%v/certs/%v", ProxyBaseDir, createCertFileName(hostname))
+	keyFilePath := fmt.Sprintf("%v/certs/%v", ProxyBaseDir, createKeyFileName(hostname))
+
+	config.Tls.Certificates = append(config.Tls.Certificates, TlsFilesConfig{CertFile: certFilePath, KeyFile: keyFilePath})
+
+	return yaml.Marshal(&config)
+}
+
+// createCertFileName returns the filename for a certificate for the specified
+// hostname.
+func createCertFileName(hostname string) string {
+	return fmt.Sprintf("%v.pem", hostname)
+}
+
+// createKeyFileName returns the filename for a key file for the specified
+// hostname.
+func createKeyFileName(hostname string) string {
+	return fmt.Sprintf("%v-key.pem", hostname)
+}
+
+// ensureDynamicConfig ensures both that the certificates directory exists,
+// and that the Traefik dynamic config exists as well.
+func ensureDynamicConfig() error {
+	if err := os.MkdirAll(certificatesDir, 0755); err != nil {
+		return err
+	}
+
+	if _, err := os.Stat(dynamicConfigPath); os.IsNotExist(err) {
+		if err := os.WriteFile(dynamicConfigPath, []byte(defaultConfig), 0755); err != nil {
+			return err
+		} else {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/lib/proxy/proxy.go
+++ b/lib/proxy/proxy.go
@@ -28,7 +28,8 @@ var dynamicConfigPath = fmt.Sprintf("%v/.falcon/dynamic.yml", os.Getenv("HOME"))
 var containerConfig *container.Config = &container.Config{
 	Image: ProxyImageName,
 	ExposedPorts: nat.PortSet{
-		"80": struct{}{},
+		"80":  struct{}{},
+		"443": struct{}{},
 	},
 	Labels: map[string]string{
 		"traefik.enable":                                         "true",
@@ -48,6 +49,12 @@ var hostConfig *container.HostConfig = &container.HostConfig{
 			{
 				HostIP:   "0.0.0.0",
 				HostPort: "80",
+			},
+		},
+		"443": []nat.PortBinding{
+			{
+				HostIP:   "0.0.0.0",
+				HostPort: "443",
 			},
 		},
 	},

--- a/lib/proxy/proxy.go
+++ b/lib/proxy/proxy.go
@@ -11,9 +11,9 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const ProxyImageName = "hawkbawk/falcon-proxy"
-const ProxyContainerName = "falcon-proxy"
-const ProxyConfigDir = "/usr/src/app/config"
+const proxyImageName = "hawkbawk/falcon-proxy"
+const proxyContainerName = "falcon-proxy"
+const proxyConfigDir = "/usr/src/app/config"
 const defaultConfig = `
 # This is where falcon will add any info about any certificates that it creates for you.
 # Alternatively, you can put any info about your own certificates here.
@@ -27,7 +27,7 @@ var certificatesDir = fmt.Sprintf("%v/certs", configDir)
 var dynamicConfigPath = fmt.Sprintf("%v/dynamic.yml", configDir)
 
 var containerConfig *container.Config = &container.Config{
-	Image: ProxyImageName,
+	Image: proxyImageName,
 	ExposedPorts: nat.PortSet{
 		"80":  struct{}{},
 		"443": struct{}{},
@@ -46,7 +46,7 @@ var hostConfig *container.HostConfig = &container.HostConfig{
 		// certificates and dynamic config due to some fsnotify issues that happen
 		// when you mount specific files. This ensures Traefik picks up on our
 		// changes to the dynamic config.
-		fmt.Sprintf("%v:%v", configDir, ProxyConfigDir),
+		fmt.Sprintf("%v:%v", configDir, proxyConfigDir),
 	},
 	PortBindings: nat.PortMap{
 		"80": []nat.PortBinding{
@@ -77,12 +77,12 @@ type DynamicConfig struct {
 
 // Start starts up the falcon-proxy so that it can start forwarding requests.
 func Start(client docker.DockerClient) error {
-	return client.StartContainer(ProxyImageName, hostConfig, containerConfig, ProxyContainerName)
+	return client.StartContainer(proxyImageName, hostConfig, containerConfig, proxyContainerName)
 }
 
 // Stop stops the falcon-proxy container.
 func Stop(client docker.DockerClient) error {
-	return client.StopAndRemoveContainer(ProxyContainerName)
+	return client.StopAndRemoveContainer(proxyContainerName)
 }
 
 // EnableTlsForHost creates the certificate files necessary for the specified
@@ -144,8 +144,8 @@ func addFilesToConfig(hostname string, data []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	certFilePath := fmt.Sprintf("%v/certs/%v", ProxyConfigDir, createCertFileName(hostname))
-	keyFilePath := fmt.Sprintf("%v/certs/%v", ProxyConfigDir, createKeyFileName(hostname))
+	certFilePath := fmt.Sprintf("%v/certs/%v", proxyConfigDir, createCertFileName(hostname))
+	keyFilePath := fmt.Sprintf("%v/certs/%v", proxyConfigDir, createKeyFileName(hostname))
 
 	config.Tls.Certificates = append(config.Tls.Certificates, TlsFilesConfig{CertFile: certFilePath, KeyFile: keyFilePath})
 

--- a/lib/proxy/proxy.go
+++ b/lib/proxy/proxy.go
@@ -40,7 +40,8 @@ var containerConfig *container.Config = &container.Config{
 var hostConfig *container.HostConfig = &container.HostConfig{
 	Binds: []string{
 		"/var/run/docker.sock:/var/run/docker.sock:ro",
-		"~/.falcon:/usr/src/app",
+		fmt.Sprintf("%v:%v/certs", certificatesDir, ProxyBaseDir),
+		fmt.Sprintf("%v:%v/dynamic.yml", dynamicConfigPath, ProxyBaseDir),
 	},
 	PortBindings: nat.PortMap{
 		"80": []nat.PortBinding{

--- a/lib/proxy/proxy.go
+++ b/lib/proxy/proxy.go
@@ -13,7 +13,7 @@ import (
 
 const ProxyImageName = "hawkbawk/falcon-proxy"
 const ProxyContainerName = "falcon-proxy"
-const ProxyConfigPath = "/usr/src/app/config"
+const ProxyConfigDir = "/usr/src/app/config"
 const defaultConfig = `
 # This is where falcon will add any info about any certificates that it creates for you.
 # Alternatively, you can put any info about your own certificates here.
@@ -22,9 +22,9 @@ tls:
   certificates:
 `
 
-var configPath = fmt.Sprintf("%v/.falcon", os.Getenv("HOME"))
-var certificatesDir = fmt.Sprintf("%v/certs", configPath)
-var dynamicConfigPath = fmt.Sprintf("%v/dynamic.yml", configPath)
+var configDir = fmt.Sprintf("%v/.falcon", os.Getenv("HOME"))
+var certificatesDir = fmt.Sprintf("%v/certs", configDir)
+var dynamicConfigPath = fmt.Sprintf("%v/dynamic.yml", configDir)
 
 var containerConfig *container.Config = &container.Config{
 	Image: ProxyImageName,
@@ -46,7 +46,7 @@ var hostConfig *container.HostConfig = &container.HostConfig{
 		// certificates and dynamic config due to some fsnotify issues that happen
 		// when you mount specific files. This ensures Traefik picks up on our
 		// changes to the dynamic config.
-		fmt.Sprintf("%v:%v", certificatesDir, ProxyConfigPath),
+		fmt.Sprintf("%v:%v", configDir, ProxyConfigDir),
 	},
 	PortBindings: nat.PortMap{
 		"80": []nat.PortBinding{
@@ -144,8 +144,8 @@ func addFilesToConfig(hostname string, data []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	certFilePath := fmt.Sprintf("%v/certs/%v", ProxyConfigPath, createCertFileName(hostname))
-	keyFilePath := fmt.Sprintf("%v/certs/%v", ProxyConfigPath, createKeyFileName(hostname))
+	certFilePath := fmt.Sprintf("%v/certs/%v", ProxyConfigDir, createCertFileName(hostname))
+	keyFilePath := fmt.Sprintf("%v/certs/%v", ProxyConfigDir, createKeyFileName(hostname))
 
 	config.Tls.Certificates = append(config.Tls.Certificates, TlsFilesConfig{CertFile: certFilePath, KeyFile: keyFilePath})
 

--- a/lib/proxy/proxy_suite_test.go
+++ b/lib/proxy/proxy_suite_test.go
@@ -1,0 +1,13 @@
+package proxy
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestProxy(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Proxy Suite")
+}

--- a/lib/proxy/proxy_test.go
+++ b/lib/proxy/proxy_test.go
@@ -2,7 +2,6 @@ package proxy
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/Hawkbawk/falcon/mocks/mock_docker"
 	"github.com/golang/mock/gomock"
@@ -71,13 +70,7 @@ var _ = Describe("Proxy", func() {
 		It("tries to call mkcert to make the certs in the right directory", func() {
 			Expect(createTlsFiles(hostname, cmdRunner)).To(Succeed())
 
-			currDir, err := os.Getwd()
-
-			if err != nil {
-				Fail("Unable to check current working directory to verify we're in the certificates directory.")
-			}
 			Expect(argList[0]).To(Equal(fmt.Sprintf("mkcert %v", hostname)))
-			Expect(currDir).To(Equal(certificatesDir))
 		})
 
 		It("returns an error if the command fails", func() {

--- a/lib/proxy/proxy_test.go
+++ b/lib/proxy/proxy_test.go
@@ -25,14 +25,14 @@ var _ = Describe("Proxy", func() {
 
 	Describe("Start", func() {
 		It("tries to start the proxy container and returns no errors", func() {
-			mockClient.EXPECT().StartContainer(ProxyImageName, hostConfig, containerConfig, ProxyContainerName).Return(nil)
+			mockClient.EXPECT().StartContainer(proxyImageName, hostConfig, containerConfig, proxyContainerName).Return(nil)
 
 			Expect(Start(mockClient)).To(Succeed())
 		})
 
 		It("returns an error if the container can't be started", func() {
 			err := fmt.Errorf("problems!")
-			mockClient.EXPECT().StartContainer(ProxyImageName, hostConfig, containerConfig, ProxyContainerName).Return(err)
+			mockClient.EXPECT().StartContainer(proxyImageName, hostConfig, containerConfig, proxyContainerName).Return(err)
 
 			Expect(Start(mockClient)).To(Equal(err))
 		})
@@ -40,14 +40,14 @@ var _ = Describe("Proxy", func() {
 
 	Describe("Stop", func() {
 		It("tries to stop the proxy container and returns no errors", func() {
-			mockClient.EXPECT().StopAndRemoveContainer(ProxyContainerName).Return(nil)
+			mockClient.EXPECT().StopAndRemoveContainer(proxyContainerName).Return(nil)
 
 			Expect(Stop(mockClient)).To(Succeed())
 		})
 
 		It("returns an error if the container can't be stopped", func() {
 			err := fmt.Errorf("problems!")
-			mockClient.EXPECT().StopAndRemoveContainer(ProxyContainerName).Return(err)
+			mockClient.EXPECT().StopAndRemoveContainer(proxyContainerName).Return(err)
 
 			Expect(Stop(mockClient)).To(Equal(err))
 		})

--- a/lib/proxy/proxy_test.go
+++ b/lib/proxy/proxy_test.go
@@ -129,7 +129,7 @@ tls:
   certificates:
 	  ---- invalid yaml -----
 `
-			Expect(addFilesToConfig(hostname, []byte(testData))).NotTo(Succeed())
+			Expect(addFilesToConfig(hostname, []byte(testData))).Error().Should(HaveOccurred())
 		})
 	})
 

--- a/lib/proxy/proxy_test.go
+++ b/lib/proxy/proxy_test.go
@@ -1,0 +1,147 @@
+package proxy
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Hawkbawk/falcon/mocks/mock_docker"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v2"
+)
+
+var _ = Describe("Proxy", func() {
+	var (
+		ctrl       *gomock.Controller
+		mockClient *mock_docker.MockDockerClient
+		hostname   = "example.com"
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockClient = mock_docker.NewMockDockerClient(ctrl)
+	})
+
+	Describe("Start", func() {
+		It("tries to start the proxy container and returns no errors", func() {
+			mockClient.EXPECT().StartContainer(ProxyImageName, hostConfig, containerConfig, ProxyContainerName).Return(nil)
+
+			Expect(Start(mockClient)).To(Succeed())
+		})
+
+		It("returns an error if the container can't be started", func() {
+			err := fmt.Errorf("problems!")
+			mockClient.EXPECT().StartContainer(ProxyImageName, hostConfig, containerConfig, ProxyContainerName).Return(err)
+
+			Expect(Start(mockClient)).To(Equal(err))
+		})
+	})
+
+	Describe("Stop", func() {
+		It("tries to stop the proxy container and returns no errors", func() {
+			mockClient.EXPECT().StopAndRemoveContainer(ProxyContainerName).Return(nil)
+
+			Expect(Stop(mockClient)).To(Succeed())
+		})
+
+		It("returns an error if the container can't be stopped", func() {
+			err := fmt.Errorf("problems!")
+			mockClient.EXPECT().StopAndRemoveContainer(ProxyContainerName).Return(err)
+
+			Expect(Stop(mockClient)).To(Equal(err))
+		})
+	})
+
+	Describe("createTlsFiles", func() {
+		var (
+			argList   []string
+			err       error
+			cmdRunner = func(cmd string) error {
+				argList = append(argList, cmd)
+				return err
+			}
+		)
+
+		BeforeEach(func() {
+			argList = make([]string, 0)
+			err = nil
+		})
+
+		It("tries to call mkcert to make the certs in the right directory", func() {
+			Expect(createTlsFiles(hostname, cmdRunner)).To(Succeed())
+
+			currDir, err := os.Getwd()
+
+			if err != nil {
+				Fail("Unable to check current working directory to verify we're in the certificates directory.")
+			}
+			Expect(argList[0]).To(Equal(fmt.Sprintf("mkcert %v", hostname)))
+			Expect(currDir).To(Equal(certificatesDir))
+		})
+
+		It("returns an error if the command fails", func() {
+			err = fmt.Errorf("couldn't do that chief!")
+
+			result := createTlsFiles(hostname, cmdRunner)
+			Expect(result).To(Equal(err))
+		})
+	})
+
+	Describe("addFilesToConfig", func() {
+		var (
+			testData = `
+tls:
+  certificates:
+    - certFile: /example.pem
+		  keyFile: /example-key.pem
+`
+			expectedResult map[interface{}]interface{}
+		)
+
+		BeforeEach(func() {
+
+			expectedResult = make(map[interface{}]interface{})
+
+			expectedConfig := `
+tls:
+  certificates:
+    - certFile: /example.pem
+		  keyFile: /example-key.pem
+    - certFile: /usr/src/app/certs/example.com.pem
+      keyFile: /usr/src/app/certs/example.com-key.pem
+`
+			yaml.Unmarshal([]byte(expectedConfig), &expectedResult)
+		})
+
+		It("adds the hostname files to the config", func() {
+			result, _ := addFilesToConfig(hostname, []byte(testData))
+
+			resultUnmarshalled := make(map[interface{}]interface{})
+
+			yaml.Unmarshal(result, &resultUnmarshalled)
+			Expect(resultUnmarshalled).To(Equal(expectedResult))
+		})
+
+		It("returns an error if it can't unmarshal the config", func() {
+			testData = `
+tls:
+  certificates:
+	  ---- invalid yaml -----
+`
+			Expect(addFilesToConfig(hostname, []byte(testData))).NotTo(Succeed())
+		})
+	})
+
+	Describe("createCertFileName", func() {
+		It("creates the right file name", func() {
+			Expect(createCertFileName(hostname)).To(Equal("example.com.pem"))
+		})
+	})
+
+	Describe("createKeyFileName", func() {
+		It("creates the right file name", func() {
+			Expect(createKeyFileName(hostname)).To(Equal("example.com-key.pem"))
+		})
+	})
+})


### PR DESCRIPTION
TLS support is finally working! To enable TLS, it's as simple as adding three Traefik labels to your container(s), generating the certificate, and then starting falcon up! It's pretty easy, but I think that it could still possibly be made even easier. For now though, I'm just happy that TLS is working! This is really big news for any applications that need TLS support.